### PR TITLE
Fix #6 for RubyTextMeshProUGUI

### DIFF
--- a/Assets/RubyTextMeshPro/Source/RubyTextMeshProUGUI.cs
+++ b/Assets/RubyTextMeshPro/Source/RubyTextMeshProUGUI.cs
@@ -59,7 +59,8 @@ namespace TMPro
             if (m_enableAutoSizing)
             {
                 // change auto size timing, update ruby tag size.
-                SetTextCustom(m_uneditedText);
+                text = ReplaceRubyTags(m_uneditedText);
+                base.ForceMeshUpdate(ignoreActiveState,forceTextReparsing);
             }
         }
 


### PR DESCRIPTION
Just applying the fix #6 to the RubyTextMeshProUGUI component.