### PR TITLE
uGUI のタグにてダブルクォーテーションがルビとして表示されてしまうのを回避

### DIFF
--- a/Assets/RubyTextMeshPro/Source/RubyTextMeshProUGUI.cs
+++ b/Assets/RubyTextMeshPro/Source/RubyTextMeshProUGUI.cs
@@ -14,7 +14,7 @@ namespace TMPro
         }
 
         // ruby tag
-        private static readonly Regex RubyRegex = new Regex(@"<r(uby)?=(?<ruby>[\s\S]*?)>(?<val>[\s\S]*?)<\/r(uby)?>");
+        private static readonly Regex RubyRegex = new Regex(@"<r(uby)?=""?(?<ruby>[\s\S]*?)""?>(?<val>[\s\S]*?)<\/r(uby)?>");
 
         [Tooltip("v offset ruby. (em, px, %).")]
         [SerializeField] private string rubyVerticalOffset = "1em";


### PR DESCRIPTION
ダブルクォーテーションがルビとして認識されていたので RubyTextMeshPro 内の RubyRegex に合わせました